### PR TITLE
GitHub actions

### DIFF
--- a/.github/workflows/ubuntu_macos.yaml
+++ b/.github/workflows/ubuntu_macos.yaml
@@ -1,0 +1,55 @@
+
+# Github actions file for checking the build of HoTT-intro/Agda on Ubuntu and macOS 
+name: Ubuntu / macOS
+
+# We trigger this action on pushes to the repo and on pull_requests
+on:
+  - push
+  - pull_request
+
+jobs:
+  build:
+    strategy:
+      # We don't stop other jobs from finishing if one fails
+      fail-fast: false
+
+      matrix:
+        # We test on ubuntu-latest and macos-latest
+        # this might need to be modified if we also want to test windows also
+        include:
+            # Operating system
+          - os: ubuntu-latest
+            # Package manger
+            pm: "sudo apt-get"
+            # Package manager flags
+            pm-flags: "-y" # We need to tell apt-get "yes" when it prompts
+            
+          - os: macos-latest
+            pm: "brew"
+            
+
+    # Run on an entry in the os coloumn of the matrix
+    runs-on: ${{ matrix.os }}
+
+    # Steps of this action
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v1
+
+      - name: Update package listings
+        run: ${{ matrix.pm }} update
+
+      - name: Install cabal-install
+        run: ${{ matrix.pm }} install ${{ matrix.flags }} cabal-install
+        
+      - name: Update cabal listings
+        run: cabal update
+
+      - name: Install alex and happy with cabal
+        run: cabal install alex happy
+      
+      - name: Install Agda with cabal
+        run: cabal install Agda-2.6.1
+
+      - name: Build book
+        run: agda-2.6.1 book.agda

--- a/book.agda
+++ b/book.agda
@@ -1,0 +1,32 @@
+{-# OPTIONS --without-K --exact-split #-}
+
+module book where
+
+open import book.00-preamble public
+open import book.02-pi public
+open import book.03-natural-numbers public
+open import book.04-inductive-types public
+open import book.05-identity-types public
+open import book.06-universes public
+open import book.07-finite-types public
+open import book.08-decidability-in-number-theory public
+open import book.08-equivalences public
+open import book.09-contractible-types public
+open import book.10-fundamental-theorem public
+open import book.11-truncation-levels public
+open import book.12-function-extensionality public
+open import book.12-function-extensionality-solutions public
+open import book.13-propositional-truncation public
+open import book.13-propositional-truncation-solutions public
+open import book.14-univalence public
+open import book.15-groups public
+open import book.16-sets public
+open import book.17-number-theory public
+open import book.18-circle public
+open import book.19-fundamental-cover public
+open import book.20-pullbacks public
+open import book.21-pushouts public
+open import book.22-cubical-diagrams public
+open import book.22-descent public
+open import book.23-id-pushout public
+open import book.24-sequences public


### PR DESCRIPTION
Here is a github actions script. <s>As you can see it should run on this PR also.</s> I've commented the script to make it easy to understand.

We check both the latest ubuntu and macOS.

Unfortunately, Agda-2.6.1 takes around an hour to build! And since this script builds agda from scratch our library will take some time to check.

Once that has finished it will attempt to build the file `book.agda` (which is new). This just imports everything in `book/`.

All the imports a public but this will probably be removed. I was in the middle of indexing `extra/` but I have ran out of time. Hopefully, github actions succeeds, but if not I will try to fix it before we merge.