### PR TITLE
Bumb to agda 2.6.1.3

### DIFF
--- a/.github/workflows/ubuntu_macos.yaml
+++ b/.github/workflows/ubuntu_macos.yaml
@@ -14,6 +14,8 @@ jobs:
       fail-fast: false
 
       matrix:
+        agda-version: [ 2.6.1.3 ]
+      
         # We test on ubuntu-latest and macos-latest
         # this might need to be modified if we also want to test windows also
         include:
@@ -50,8 +52,8 @@ jobs:
         with:
           path: |
             ~/.cabal
-          # We cache each os sperately
-          key: ${{ matrix.os }}
+          # We cache each os and agda version seperately
+          key: ${{ matrix.os }}-${{ matrix.agda-version}}
 
         # If we have not already cached update cabal listings
       - name: Update cabal listings
@@ -66,7 +68,7 @@ jobs:
         # If we have not already cached install agda
       - name: Install Agda with cabal
         if: steps.cache.outputs.cache-hit != 'true'
-        run: cabal install Agda-2.6.1.3
+        run: cabal install Agda-${{ matrix.agda-version }}
       
       - name: Build book
         run: ~/.cabal/bin/agda book.agda

--- a/.github/workflows/ubuntu_macos.yaml
+++ b/.github/workflows/ubuntu_macos.yaml
@@ -66,7 +66,7 @@ jobs:
         # If we have not already cached install agda
       - name: Install Agda with cabal
         if: steps.cache.outputs.cache-hit != 'true'
-        run: cabal install Agda-2.6.1
+        run: cabal install Agda-2.6.1.3
       
       - name: Build book
         run: ~/.cabal/bin/agda book.agda

--- a/.github/workflows/ubuntu_macos.yaml
+++ b/.github/workflows/ubuntu_macos.yaml
@@ -14,8 +14,11 @@ jobs:
       fail-fast: false
 
       matrix:
+        # OS
+        os: [ ubuntu-latest , macos-latest ]
+        # Version of agda
         agda-version: [ 2.6.1.3 ]
-      
+        
         # We test on ubuntu-latest and macos-latest
         # this might need to be modified if we also want to test windows also
         include:


### PR DESCRIPTION
I've bumbed to a more recent version of agda. This should fix the CI which was broken around 4 months ago. The issue is that Agda-2.6.1.0 isn't compatibile with the newer versions of GHC. However version 2.6.1.3 is, and also happens to use less memory when building.

I've also made it easier to bumb the agda version in the CI, and updated the caching accordingly.